### PR TITLE
Fix incompatibility with WeirdAddons

### DIFF
--- a/src/main/java/carpetfixes/mixins/blockUpdates/SpongeBlock_missingUpdateMixin.java
+++ b/src/main/java/carpetfixes/mixins/blockUpdates/SpongeBlock_missingUpdateMixin.java
@@ -20,7 +20,7 @@ public class SpongeBlock_missingUpdateMixin extends Block {
 
 
     @ModifyConstant(
-            method = "Lnet/minecraft/block/SpongeBlock;update(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)V",
+            method = "update(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)V",
             require = 0,
             constant = @Constant(intValue = 2)
     )

--- a/src/main/java/carpetfixes/mixins/blockUpdates/SpongeBlock_missingUpdateMixin.java
+++ b/src/main/java/carpetfixes/mixins/blockUpdates/SpongeBlock_missingUpdateMixin.java
@@ -19,16 +19,12 @@ public class SpongeBlock_missingUpdateMixin extends Block {
     public SpongeBlock_missingUpdateMixin(Settings settings) {super(settings);}
 
 
-    @ModifyArg(
-            method = "update(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)V",
+    @ModifyConstant(
+            method = "Lnet/minecraft/block/SpongeBlock;update(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)V",
             require = 0,
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"
-            ),
-            index = 2
+            constant = @Constant(intValue = 2)
     )
-    protected int spongeUpdate(int value) {
+    private int spongeUpdate(int value) {
         return CarpetFixesSettings.spongeUpdateFix ? 3 : 2;
     }
 }

--- a/src/main/java/carpetfixes/mixins/blockUpdates/SpongeBlock_missingUpdateMixin.java
+++ b/src/main/java/carpetfixes/mixins/blockUpdates/SpongeBlock_missingUpdateMixin.java
@@ -24,7 +24,7 @@ public class SpongeBlock_missingUpdateMixin extends Block {
             require = 0,
             constant = @Constant(intValue = 2)
     )
-    private int spongeUpdate(int value) {
+    protected int spongeUpdate(int value) {
         return CarpetFixesSettings.spongeUpdateFix ? 3 : 2;
     }
 }


### PR DESCRIPTION
This pull request will fix this issue https://github.com/fxmorin/WeirdAddons/issues/6


The problem:
 - WeirdAddons and carpet-fixes hooks into `update(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)V` at the same target `"Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"`
 - WeirdAddons changes the signature from 3 to 4 parameters of `world.SetBlockState` on `update` method.
 - Carpet-fixes then tries to modify the 3rd argument, but it fails because the type of the argument is not an int anymore but a BlockState type.
 
Solution:
 - Make carpet-fixes to find the constant value (`2`) and change it intead of trying to modify `world.SetBlockState` and avoid incompatibility problem with weirdaddons


note: I'm not a fabric expert so maybe my solution could be better, this is the second time messing with it, but I tried the solution and is working fine, with and without weirdaddons