### PR TITLE
Fix: optimizedNeighborUpdater SixwayUpdates

### DIFF
--- a/src/main/java/carpetfixes/helpers/MemEfficientNeighborUpdater.java
+++ b/src/main/java/carpetfixes/helpers/MemEfficientNeighborUpdater.java
@@ -229,16 +229,14 @@ public class MemEfficientNeighborUpdater implements NeighborUpdater {
         } else if(type == 3) {
             int dir = queuedUpdates[getPointer() + 4];
             int currentDirIndex = queuedUpdates[getPointer() + 5];
-            boolean ret = false;
             if (dir != 6 && currentDirIndex < UPDATE_AMT && UPDATE_ORDER[currentDirIndex] == Direction.byId(dir)) {
                 currentDirIndex++;
-                ret = true;
             }
             queuedUpdates[getPointer() + 5] = currentDirIndex + 1;
-            if (currentDirIndex != UPDATE_AMT) pointer++;
-            if (ret || currentDirIndex == UPDATE_AMT) return;
+            if (currentDirIndex == UPDATE_AMT) return;
             BlockPos pos = getPos(getPointer() + 1);
             BlockPos blockPos = pos.offset(UPDATE_ORDER[currentDirIndex]);
+            if (currentDirIndex != UPDATE_AMT) pointer++;
             world.getBlockState(blockPos).neighborUpdate(
                     world,                                     // World
                     blockPos,                                  // Pos


### PR DESCRIPTION
optimizedNeighborUpdater was handling SixWay Updates in a way that broke it, The fixt consist of moving the check to see if the SixWay update was completed, and getting the position of the block before updating the pointer.

fixes #104 