### PR TITLE
fix: #110

### DIFF
--- a/src/main/java/carpetfixes/settings/CarpetFixesMixinConfigPlugin.java
+++ b/src/main/java/carpetfixes/settings/CarpetFixesMixinConfigPlugin.java
@@ -22,9 +22,7 @@ public class CarpetFixesMixinConfigPlugin extends RestrictiveMixinConfigPlugin {
     protected void onRestrictionCheckFailed(String mixinClassName, String reason) {}
 
     @Override
-    public void onLoad(String mixinPackage) {
-        MixinExtrasBootstrap.init();
-    }
+    public void onLoad(String mixinPackage) {}
 
     @Override
     public String getRefMapperConfig() {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,9 @@
   "entrypoints": {
     "main": [
       "carpetfixes.CarpetFixesServer"
+    ],
+    "preLaunch": [
+      "com.llamalad7.mixinextras.MixinExtrasBootstrap::init"
     ]
   },
   "mixins": [


### PR DESCRIPTION
Fixes #110 by moving `MixinExtrasBootstrap::init()` from `IMixinConfigPlugin#onLoad` to fabrics preLaunch entry point. See [MixinExtras](https://github.com/LlamaLad7/MixinExtras/#footnotes) and [discord](https://discord.com/channels/507304429255393322/566418023372816394/1037412871761567845) (fabric discord) for further information on this issue.