### PR TITLE
fix `MC-120083` with `spectatorAdvancementGrantingFix`

### DIFF
--- a/src/main/java/carpetfixes/CFSettings.java
+++ b/src/main/java/carpetfixes/CFSettings.java
@@ -404,6 +404,12 @@ public class CFSettings {
     )
     public static boolean foxesDisregardPowderSnowFix = false;
 
+    //by Jack
+    @Rule(
+            categories = {BUGFIX}
+    )
+    public static boolean spectatorAdvancementGrantingFix = false;
+
     //by FX - PR0CESS
     @Rule(
             categories = {BUGFIX}

--- a/src/main/java/carpetfixes/mixins/playerFixes/PlayerAdvancementTracker_grantCriterionMixin.java
+++ b/src/main/java/carpetfixes/mixins/playerFixes/PlayerAdvancementTracker_grantCriterionMixin.java
@@ -1,0 +1,37 @@
+package carpetfixes.mixins.playerFixes;
+
+import carpetfixes.CFSettings;
+import net.minecraft.advancement.Advancement;
+import net.minecraft.advancement.PlayerAdvancementTracker;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.world.GameMode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Fixes an Issue allowing for players in Spectator mode to be granted Advancement Criteria
+ */
+
+
+@Mixin(PlayerAdvancementTracker.class)
+public class PlayerAdvancementTracker_grantCriterionMixin {
+
+    @Shadow
+    private ServerPlayerEntity owner;
+
+    @Inject(
+            method = "grantCriterion",
+            at = @At("HEAD"),
+            cancellable = true)
+    public void grantCriterion(Advancement advancement, String criterionName, CallbackInfoReturnable<Boolean> cir) {
+
+        if (CFSettings.spectatorAdvancementGrantingFix &&
+                owner.interactionManager.getGameMode().equals(GameMode.SPECTATOR))
+            cir.cancel();
+
+
+    }
+}

--- a/src/main/resources/assets/carpet-fixes/lang/en_us.json
+++ b/src/main/resources/assets/carpet-fixes/lang/en_us.json
@@ -164,6 +164,8 @@
 	"carpet-fixes.rule.followParentGoalBreaksMovementFix.extra": "[MC-149838](https://bugs.mojang.com/browse/MC-149838)",
 	"carpet-fixes.rule.foxesDisregardPowderSnowFix.desc": "Fixes Foxes not Respecting Powder Snow as a Snow Like block, Therefore Powder Snow would not have the same effect as Snow does",
 	"carpet-fixes.rule.foxesDisregardPowderSnowFix.extra": "[MC-230660](https://bugs.mojang.com/browse/MC-230660)",
+	"carpet-fixes.rule.spectatorAdvancementGrantingFix.desc": "Fixes advancement criteria being granted to players in Spectator mode",
+	"carpet-fixes.rule.spectatorAdvancementGrantingFix.extra": "[MC-120083](https://bugs.mojang.com/browse/MC-120083)",
 	"carpet-fixes.rule.foxesDropItemsWithLootOffFix.desc": "Fixes gamerule doMobLoot not effecting foxes from dropping their items",
 	"carpet-fixes.rule.foxesDropItemsWithLootOffFix.extra": "[MC-153010](https://bugs.mojang.com/browse/MC-153010)",
 	"carpet-fixes.rule.frictionlessEntitiesFix.desc": "Fixes frictionless goats & frogs, currently requires to be modified per mob",

--- a/src/main/resources/carpet-fixes.mixins.json
+++ b/src/main/resources/carpet-fixes.mixins.json
@@ -266,6 +266,7 @@
     "playerFixes.Entity_blockCollisionMixin",
     "playerFixes.EntityDataObject_dataPlayerMixin",
     "playerFixes.LivingEntity_sleepingKillsMixin",
+    "playerFixes.PlayerAdvancementTracker_grantCriterionMixin",
     "playerFixes.PlayerEntity_absorptionMixin",
     "playerFixes.PlayerEntity_enchantmentCostMixin",
     "playerFixes.PlayerEntity_hungerMixin",


### PR DESCRIPTION
I am unsure if this is "working as intended" but seems like it would not be? it is up to you to decide if you think it is before Mojang  says if it is on the Bug Tracker. 
I tested it all ofc and it works.
Hopefully I did not format anything wrong.


Also If you want to rename it you can ofc.