### PR TITLE
New Rule: endermanDontTakeExplosionDamageFix

### DIFF
--- a/src/main/java/carpetfixes/CFSettings.java
+++ b/src/main/java/carpetfixes/CFSettings.java
@@ -116,6 +116,12 @@ public class CFSettings {
     )
     public static boolean endermanUselessMinecartTeleportingFix = false;
 
+    //by B14CK313
+    @Rule(
+            categories = {BUGFIX, VANILLA}
+    )
+    public static boolean endermanDontTakeExplosionDamageFix = false;
+
     //by FX - PR0CESS
     @Rule(
             categories = {BUGFIX}

--- a/src/main/java/carpetfixes/mixins/entityFixes/EndermanEntity_explosionDamageMixin.java
+++ b/src/main/java/carpetfixes/mixins/entityFixes/EndermanEntity_explosionDamageMixin.java
@@ -1,0 +1,50 @@
+package carpetfixes.mixins.entityFixes;
+
+import carpetfixes.CFSettings;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.mob.EndermanEntity;
+import net.minecraft.entity.projectile.thrown.PotionEntity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Fixes the endermen not being able to take damage from wither and tnt explosions
+ * (<a href="https://bugs.mojang.com/browse/MC-258561">MC-258561</a>)
+ */
+
+@Mixin(EndermanEntity.class)
+public abstract class EndermanEntity_explosionDamageMixin extends LivingEntity {
+
+    protected EndermanEntity_explosionDamageMixin(EntityType<? extends LivingEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+
+    @SuppressWarnings("UnusedReturnValue")
+    @Invoker("teleportRandomly")
+    public abstract boolean invokeTeleportRandomly();
+
+
+    @Inject(
+            method = "damage",
+            at = @At(value = "HEAD"),
+            cancellable = true
+    )
+    private void damageFromExplosion(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        if (CFSettings.endermanDontTakeExplosionDamageFix
+                && !source.isProjectile()
+                && !(source.getSource() instanceof PotionEntity)) {
+            boolean bl = super.damage(source, amount);
+            if (!this.world.isClient() && !(source.getAttacker() instanceof LivingEntity) && this.random.nextInt(10) != 0) {
+                this.invokeTeleportRandomly();
+            }
+            cir.setReturnValue(bl);
+        }
+    }
+}

--- a/src/main/resources/assets/carpet-fixes/lang/en_us.json
+++ b/src/main/resources/assets/carpet-fixes/lang/en_us.json
@@ -130,6 +130,8 @@
 	"carpet-fixes.rule.enderDragonDoesntDropBlocksFix.extra": "[MC-220519](https://bugs.mojang.com/browse/MC-220519)",
 	"carpet-fixes.rule.endermanAvoidProjectilesInVehicleFix.desc": "Fixes enderman doing teleporting effects and sounds and avoiding projectiles while in a vehicle",
 	"carpet-fixes.rule.endermanAvoidProjectilesInVehicleFix.extra": "[MC-183446](https://bugs.mojang.com/browse/MC-183446)",
+	"carpet-fixes.rule.endermanDontTakeExplosionDamageFix.desc": "Fixes the endermen not being able to take damage from wither and tnt explosions",
+	"carpet-fixes.rule.endermanDontTakeExplosionDamageFix.extra": "[MC-258561](https://bugs.mojang.com/browse/MC-258561)",
 	"carpet-fixes.rule.endermanDontUpdateOnPlaceFix.extra": "Only applies if you use datapacks or mods. E.x. Enderman placing a wither skull will not spawn a wither\n[MC-183054](https://bugs.mojang.com/browse/MC-183054)",
 	"carpet-fixes.rule.endermanDontUpdateOnPlaceFix.desc": "Fixes enderman not updating the block they place correctly",
 	"carpet-fixes.rule.endermanLowerPiercingFix.desc": "Fixes piercing projectiles lowering there piercing when 'hitting' an enderman",

--- a/src/main/resources/carpet-fixes.mixins.json
+++ b/src/main/resources/carpet-fixes.mixins.json
@@ -165,6 +165,7 @@
     "entityFixes.EndCrystalEntity_pushRespawnMixin",
     "entityFixes.EnderDragonEntity_blockDropsMixin",
     "entityFixes.EnderDragonFight_respawnMixin",
+    "entityFixes.EndermanEntity_explosionDamageMixin",
     "entityFixes.EndermanEntity_noAiTeleportMixin",
     "entityFixes.EndermanEntity_teleportingMixin",
     "entityFixes.EndermanEntity_vehicleMixin",


### PR DESCRIPTION
I gave issue #123 a shot and implemented a new rule "endermanDontTakeExplosionDamageFix" that fixes https://bugs.mojang.com/browse/MC-258561 by using the same behavior as Minecraft 1.19.4.

This is my first time with fabric, please don't hesitate to tell me if things should be done differently, I am happy to fix any mistakes I made.
That said, I am confident that this is a pretty decent implementation of this fix.