### PR TITLE
update to support 1.20.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,13 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use or https://modmuss50.me/fabric.html
-minecraft_version=1.20
+minecraft_version=1.20.4
 display_minecraft_version=1.20
-yarn_mappings=1.20+build.1
-loader_version=0.14.3
-carpet_minecraft_version=1.20
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.3
+carpet_minecraft_version=1.20.3
 # check available versions on maven for the given minecraft version you are using
-carpet_core_version=1.4.112+v230608
+carpet_core_version=1.4.128+v231205
 
 
 # Mod Properties

--- a/src/main/java/carpetfixes/mixins/advanced/MinecraftServer_autosaveDelayMixin.java
+++ b/src/main/java/carpetfixes/mixins/advanced/MinecraftServer_autosaveDelayMixin.java
@@ -10,29 +10,30 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 public class MinecraftServer_autosaveDelayMixin {
 
 
-    @ModifyConstant(
-            method = "tick(Ljava/util/function/BooleanSupplier;)V",
-            constant = @Constant(intValue = 6000)
-    )
-    public int tickAutoSave(int autoSaveDelay) {
-        return CFSettings.delayBetweenAutoSaves;
-    }
-
-    
-    @ModifyConstant(
-            method = "canExecute(Lnet/minecraft/server/ServerTask;)Z",
-            constant = @Constant(intValue = 3) //statusUpdateDelay
-    )
-    public int shouldRunWithLatency(int maxTickLatency) {
-        return CFSettings.maxTickLatency;
-    }
-
-    
-    @ModifyConstant(
-            method = "tick(Ljava/util/function/BooleanSupplier;)V",
-            constant = @Constant(longValue = 5000000000L)
-    )
-    public long customStatusUpdateDelay(long maxTickLatency) {
-        return CFSettings.statusUpdateDelay;
-    }
+// FIXME - this seems to have been rewritten
+//    @ModifyConstant(
+//            method = "tick(Ljava/util/function/BooleanSupplier;)V",
+//            constant = @Constant(intValue = 6000)
+//    )
+//    public int tickAutoSave(int autoSaveDelay) {
+//        return CFSettings.delayBetweenAutoSaves;
+//    }
+//
+//    
+//    @ModifyConstant(
+//            method = "canExecute(Lnet/minecraft/server/ServerTask;)Z",
+//            constant = @Constant(intValue = 3) //statusUpdateDelay
+//    )
+//    public int shouldRunWithLatency(int maxTickLatency) {
+//        return CFSettings.maxTickLatency;
+//    }
+//
+//    
+//    @ModifyConstant(
+//            method = "tick(Ljava/util/function/BooleanSupplier;)V",
+//            constant = @Constant(longValue = 5000000000L)
+//    )
+//    public long customStatusUpdateDelay(long maxTickLatency) {
+//        return CFSettings.statusUpdateDelay;
+//    }
 }

--- a/src/main/java/carpetfixes/mixins/blockFixes/EnchantingTableBlock_transparentMixin.java
+++ b/src/main/java/carpetfixes/mixins/blockFixes/EnchantingTableBlock_transparentMixin.java
@@ -16,7 +16,7 @@ public class EnchantingTableBlock_transparentMixin {
 
 
     @Redirect(
-            method = "canAccessBookshelf(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;" +
+            method = "canAccessPowerProvider(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;" +
                     "Lnet/minecraft/util/math/BlockPos;)Z",
             at = @At(
                     value = "INVOKE",

--- a/src/main/java/carpetfixes/mixins/blockUpdates/HopperBlock_missingUpdateMixin.java
+++ b/src/main/java/carpetfixes/mixins/blockUpdates/HopperBlock_missingUpdateMixin.java
@@ -26,7 +26,7 @@ public class HopperBlock_missingUpdateMixin extends Block {
 
     @ModifyArg(
             method = "updateEnabled(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;" +
-                    "Lnet/minecraft/block/BlockState;I)V",
+                    "Lnet/minecraft/block/BlockState;)V",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/world/World;" +

--- a/src/main/java/carpetfixes/mixins/blockUpdates/TrapdoorBlock_missingUpdateMixin.java
+++ b/src/main/java/carpetfixes/mixins/blockUpdates/TrapdoorBlock_missingUpdateMixin.java
@@ -50,7 +50,7 @@ public abstract class TrapdoorBlock_missingUpdateMixin extends HorizontalFacingB
 
 
     @Inject(
-            method = "onUse",
+            method = "flip",
             at = @At(
                     shift = At.Shift.AFTER,
                     value = "INVOKE",
@@ -59,7 +59,7 @@ public abstract class TrapdoorBlock_missingUpdateMixin extends HorizontalFacingB
             )
     )
     private void updateOnUseCorrectly(BlockState state, World world, BlockPos pos, PlayerEntity player,
-                                      Hand hand, BlockHitResult hit, CallbackInfoReturnable<ActionResult> cir) {
+                                      CallbackInfo ci) {
         if (CFSettings.trapdoorMissingUpdateFix)
             world.updateNeighbor(pos.offset(directionToUpdate(state)),state.getBlock(),pos);
     }

--- a/src/main/java/carpetfixes/mixins/blockUpdates/duplicateUpdates/RedstoneTorchBlock_updateMixin.java
+++ b/src/main/java/carpetfixes/mixins/blockUpdates/duplicateUpdates/RedstoneTorchBlock_updateMixin.java
@@ -4,7 +4,7 @@ import carpetfixes.CFSettings;
 import carpetfixes.helpers.BlockUpdateUtils;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.RedstoneTorchBlock;
-import net.minecraft.block.TorchBlock;
+import net.minecraft.block.AbstractTorchBlock;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -18,12 +18,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  */
 
 @Mixin(RedstoneTorchBlock.class)
-public abstract class RedstoneTorchBlock_updateMixin extends TorchBlock {
+public abstract class RedstoneTorchBlock_updateMixin extends AbstractTorchBlock {
 
     RedstoneTorchBlock self = (RedstoneTorchBlock)(Object)this;
 
-    protected RedstoneTorchBlock_updateMixin(Settings settings, ParticleEffect particle) {
-        super(settings, particle);
+    protected RedstoneTorchBlock_updateMixin(Settings settings) {
+        super(settings);
     }
 
 

--- a/src/main/java/carpetfixes/mixins/coreSystemFixes/StatusEffectInstance_wrongEffectMixin.java
+++ b/src/main/java/carpetfixes/mixins/coreSystemFixes/StatusEffectInstance_wrongEffectMixin.java
@@ -49,7 +49,7 @@ public abstract class StatusEffectInstance_wrongEffectMixin {
     private void addHere(LivingEntity entity, Runnable overwriteCallback, CallbackInfoReturnable<Boolean> cir) {
         if (CFSettings.brokenHiddenStatusEffectFix) {
             ((LivingEntityAccessor)entity).setEffectsChanged(true);
-            this.getEffectType().onRemoved(entity, entity.getAttributes(), this.getAmplifier());
+            this.getEffectType().onRemoved(entity.getAttributes());
         }
     }
 
@@ -63,7 +63,7 @@ public abstract class StatusEffectInstance_wrongEffectMixin {
     )
     private void removeHere(LivingEntity entity, Runnable overwriteCallback, CallbackInfoReturnable<Boolean> cir) {
         if (CFSettings.brokenHiddenStatusEffectFix) {
-            this.getEffectType().onApplied(entity, entity.getAttributes(), this.getAmplifier());
+            this.getEffectType().onApplied(entity.getAttributes(), this.getAmplifier());
         }
     }
 

--- a/src/main/java/carpetfixes/mixins/dupeFixes/saferItemTransfer/DropperBlock_dontCopyMixin.java
+++ b/src/main/java/carpetfixes/mixins/dupeFixes/saferItemTransfer/DropperBlock_dontCopyMixin.java
@@ -1,6 +1,7 @@
 package carpetfixes.mixins.dupeFixes.saferItemTransfer;
 
 import carpetfixes.CFSettings;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.DropperBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.world.ServerWorld;
@@ -24,7 +25,7 @@ public class DropperBlock_dontCopyMixin {
 
 
     @Redirect(
-            method = "dispense(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/BlockPos;)V",
+            method = "dispense(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)V",
             slice = @Slice(
                     from = @At("HEAD"),
                     to = @At(
@@ -46,7 +47,7 @@ public class DropperBlock_dontCopyMixin {
 
 
     @Redirect(
-            method = "dispense(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/BlockPos;)V",
+            method = "dispense(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)V",
             slice = @Slice(
                     from = @At(
                             value = "INVOKE",
@@ -65,10 +66,10 @@ public class DropperBlock_dontCopyMixin {
 
 
     @Inject(
-            method = "dispense(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/BlockPos;)V",
+            method = "dispense(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)V",
             at = @At("TAIL")
     )
-    private void removeInstance(ServerWorld world, BlockPos pos, CallbackInfo ci) {
+    private void removeInstance(ServerWorld world, BlockState state, BlockPos pos, CallbackInfo ci) {
         stack = ItemStack.EMPTY;
     }
 }

--- a/src/main/java/carpetfixes/mixins/entityFixes/ArmorStandEntity_damageMixin.java
+++ b/src/main/java/carpetfixes/mixins/entityFixes/ArmorStandEntity_damageMixin.java
@@ -22,7 +22,7 @@ public abstract class ArmorStandEntity_damageMixin {
             method = "damage(Lnet/minecraft/entity/damage/DamageSource;F)Z",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/entity/damage/DamageSource;getSource()Lnet/minecraft/entity/Entity;",
+                    target = "Lnet/minecraft/entity/damage/DamageSource;getAttacker()Lnet/minecraft/entity/Entity;",
                     ordinal = 0,
                     shift = At.Shift.BEFORE
             ),

--- a/src/main/java/carpetfixes/mixins/entityFixes/DrownedEntity_enchantedTridentMixin.java
+++ b/src/main/java/carpetfixes/mixins/entityFixes/DrownedEntity_enchantedTridentMixin.java
@@ -32,7 +32,7 @@ public class DrownedEntity_enchantedTridentMixin extends ZombieEntity {
 
 
     @Redirect(
-            method = "attack",
+            method = "shootAt",
             at = @At(
                     value = "NEW",
                     target = "net/minecraft/item/ItemStack"

--- a/src/main/java/carpetfixes/mixins/entityFixes/TridentEntity_fallingMixin.java
+++ b/src/main/java/carpetfixes/mixins/entityFixes/TridentEntity_fallingMixin.java
@@ -4,6 +4,7 @@ import carpetfixes.CFSettings;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -17,8 +18,8 @@ import org.spongepowered.asm.mixin.Shadow;
 @Mixin(TridentEntity.class)
 public abstract class TridentEntity_fallingMixin extends PersistentProjectileEntity {
 
-    protected TridentEntity_fallingMixin(EntityType<? extends PersistentProjectileEntity> entityType, World world) {
-        super(entityType, world);
+    protected TridentEntity_fallingMixin(EntityType<? extends PersistentProjectileEntity> entityType, World world, ItemStack stack) {
+        super(entityType, world, stack);
     }
 
     @Shadow

--- a/src/main/java/carpetfixes/mixins/playerFixes/PlayerAdvancementTracker_grantCriterionMixin.java
+++ b/src/main/java/carpetfixes/mixins/playerFixes/PlayerAdvancementTracker_grantCriterionMixin.java
@@ -2,6 +2,7 @@ package carpetfixes.mixins.playerFixes;
 
 import carpetfixes.CFSettings;
 import net.minecraft.advancement.Advancement;
+import net.minecraft.advancement.AdvancementEntry;
 import net.minecraft.advancement.PlayerAdvancementTracker;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.world.GameMode;
@@ -27,7 +28,7 @@ public class PlayerAdvancementTracker_grantCriterionMixin {
             at = @At("HEAD"),
             cancellable = true
     )
-    private void grantCriterion(Advancement advancement, String criterionName, CallbackInfoReturnable<Boolean> cir) {
+    private void grantCriterion(AdvancementEntry advancement, String criterionName, CallbackInfoReturnable<Boolean> cir) {
         if (CFSettings.spectatorAdvancementGrantingFix &&
                 owner.interactionManager.getGameMode().equals(GameMode.SPECTATOR)) {
             cir.cancel();

--- a/src/main/java/carpetfixes/mixins/playerFixes/PlayerEntity_absorptionMixin.java
+++ b/src/main/java/carpetfixes/mixins/playerFixes/PlayerEntity_absorptionMixin.java
@@ -28,7 +28,7 @@ public abstract class PlayerEntity_absorptionMixin extends LivingEntity {
 
 
     @Inject(
-            method = "setAbsorptionAmount(F)V",
+            method = "setAbsorptionAmountUnclamped(F)V",
             at = @At("RETURN")
     )
     private void onAbsorptionChanged(float amount, CallbackInfo ci) {

--- a/src/main/java/carpetfixes/mixins/redstoneFixes/AbstractRedstoneGateBlock_repeaterPriorityMixin.java
+++ b/src/main/java/carpetfixes/mixins/redstoneFixes/AbstractRedstoneGateBlock_repeaterPriorityMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
  */
 
 @Mixin(AbstractRedstoneGateBlock.class)
-public class AbstractRedstoneGateBlock_repeaterPriorityMixin extends HorizontalFacingBlock  {
+abstract public class AbstractRedstoneGateBlock_repeaterPriorityMixin extends HorizontalFacingBlock  {
 
     protected AbstractRedstoneGateBlock_repeaterPriorityMixin(Settings settings) {
         super(settings);

--- a/src/main/java/carpetfixes/mixins/utils/Entity_dimensionsMixin.java
+++ b/src/main/java/carpetfixes/mixins/utils/Entity_dimensionsMixin.java
@@ -192,7 +192,7 @@ public abstract class Entity_dimensionsMixin implements ExtendedEntity {
     }
 
     private static boolean canWorldBorderCollideAtPos(WorldBorder worldBorder, Vec3d pos, Box box) {
-        double d = Math.max(MathHelper.absMax(box.getXLength(), box.getZLength()), 1.0);
+        double d = Math.max(MathHelper.absMax(box.getLengthX(), box.getLengthZ()), 1.0);
         return worldBorder.getDistanceInsideBorder(pos.getX(), pos.getZ()) < d * 2.0 &&
                 worldBorder.contains(pos.getX(), pos.getZ(), d);
     }

--- a/src/main/resources/carpet-fixes.accesswidener
+++ b/src/main/resources/carpet-fixes.accesswidener
@@ -17,3 +17,4 @@ accessible class net/minecraft/world/chunk/PaletteResizeListener
 accessible method net/minecraft/world/chunk/ArrayPalette <init> (Lnet/minecraft/util/collection/IndexedIterable;[Ljava/lang/Object;Lnet/minecraft/world/chunk/PaletteResizeListener;II)V
 accessible method net/minecraft/world/chunk/BiMapPalette <init> (Lnet/minecraft/util/collection/IndexedIterable;ILnet/minecraft/world/chunk/PaletteResizeListener;Lnet/minecraft/util/collection/Int2ObjectBiMap;)V
 accessible field net/minecraft/block/AbstractPressurePlateBlock blockSetType Lnet/minecraft/block/BlockSetType;
+extendable method net/minecraft/entity/LivingEntity canBreatheInWater ()Z


### PR DESCRIPTION
This is an early stab at updating to 1.20.4. There are several deficiencies:

- carpetfixes.mixins.advanced.MinecraftServer_autosaveDelayMixin needs to be rewritten to match the changes in the game

- I do not understand what carpetfixes.mixins.reIntroduced.PlayerManager_LlamaRidingDupeMixin is trying to do with the "vmp" and "c2me" prefixes.

- The method call intercept to com.google.commons.collect.Maps.newHashMap() fail in carpetfixes.mixins.blockFixes.PistonBlock_pushOrderMixin and I do not understand why.

- Update suppression fixes should be removed as they are handled by TIS.

The mod does compile and work for the few fixes I have tried.

This should eventually resolve #159.